### PR TITLE
fix: note_id → feed_id 适配 xiaohongshu-mcp 官方 SDK

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -29,8 +29,8 @@ description: |
 | `status.sh` | 检查登录状态 |
 | `search.sh <关键词>` | 搜索内容 |
 | `recommend.sh` | 获取推荐列表 |
-| `post-detail.sh <note_id> <xsec_token>` | 获取帖子详情 |
-| `comment.sh <note_id> <xsec_token> <内容>` | 发表评论 |
+| `post-detail.sh <feed_id> <xsec_token>` | 获取帖子详情 |
+| `comment.sh <feed_id> <xsec_token> <内容>` | 发表评论 |
 | `user-profile.sh <user_id>` | 获取用户主页 |
 | `track-topic.sh <话题> [选项]` | 热点跟踪报告 |
 | `mcp-call.sh <tool> [args]` | 通用工具调用 |

--- a/scripts/comment.sh
+++ b/scripts/comment.sh
@@ -11,4 +11,4 @@ if [ -z "$NOTE_ID" ] || [ -z "$XSEC_TOKEN" ] || [ -z "$CONTENT" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-"$SCRIPT_DIR/mcp-call.sh" post_comment_to_feed "{\"note_id\": \"$NOTE_ID\", \"xsec_token\": \"$XSEC_TOKEN\", \"content\": \"$CONTENT\"}"
+"$SCRIPT_DIR/mcp-call.sh" post_comment_to_feed "{\"feed_id\": \"$NOTE_ID\", \"xsec_token\": \"$XSEC_TOKEN\", \"content\": \"$CONTENT\"}"

--- a/scripts/mcp-call.sh
+++ b/scripts/mcp-call.sh
@@ -6,6 +6,7 @@ set -e
 TOOL_NAME="$1"
 TOOL_ARGS="$2"
 MCP_URL="${MCP_URL:-http://localhost:18060/mcp}"
+export no_proxy="${no_proxy:+$no_proxy,}localhost,127.0.0.1"
 
 if [ -z "$TOOL_NAME" ]; then
     echo "用法: $0 <tool_name> [json_args]"
@@ -14,11 +15,11 @@ if [ -z "$TOOL_NAME" ]; then
     echo "  check_login_status    - 检查登录状态"
     echo "  search_feeds          - 搜索内容 {\"keyword\": \"...\"}"
     echo "  list_feeds            - 获取首页推荐"
-    echo "  get_feed_detail       - 获取帖子详情 {\"note_id\": \"...\", \"xsec_token\": \"...\"}"
-    echo "  post_comment_to_feed  - 发表评论 {\"note_id\": \"...\", \"xsec_token\": \"...\", \"content\": \"...\"}"
+    echo "  get_feed_detail       - 获取帖子详情 {\"feed_id\": \"...\", \"xsec_token\": \"...\"}"
+    echo "  post_comment_to_feed  - 发表评论 {\"feed_id\": \"...\", \"xsec_token\": \"...\", \"content\": \"...\"}"
     echo "  user_profile          - 获取用户主页 {\"user_id\": \"...\"}"
-    echo "  like_feed             - 点赞/取消 {\"note_id\": \"...\", \"xsec_token\": \"...\", \"like\": true}"
-    echo "  favorite_feed         - 收藏/取消 {\"note_id\": \"...\", \"xsec_token\": \"...\", \"favorite\": true}"
+    echo "  like_feed             - 点赞/取消 {\"feed_id\": \"...\", \"xsec_token\": \"...\", \"like\": true}"
+    echo "  favorite_feed         - 收藏/取消 {\"feed_id\": \"...\", \"xsec_token\": \"...\", \"favorite\": true}"
     echo "  get_login_qrcode      - 获取登录二维码"
     echo "  publish_content       - 发布图文"
     echo "  publish_with_video    - 发布视频"

--- a/scripts/post-detail.sh
+++ b/scripts/post-detail.sh
@@ -12,4 +12,4 @@ if [ -z "$NOTE_ID" ] || [ -z "$XSEC_TOKEN" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-"$SCRIPT_DIR/mcp-call.sh" get_feed_detail "{\"note_id\": \"$NOTE_ID\", \"xsec_token\": \"$XSEC_TOKEN\"}"
+"$SCRIPT_DIR/mcp-call.sh" get_feed_detail "{\"feed_id\": \"$NOTE_ID\", \"xsec_token\": \"$XSEC_TOKEN\"}"


### PR DESCRIPTION
## Summary

- `xiaohongshu-mcp` 在 [PR #167](https://github.com/xpzouying/xiaohongshu-mcp/pull/167) 迁移到官方 MCP SDK 后，MCP 工具参数名从 `note_id` 改为 `feed_id`
- 当前脚本搭配新版二进制使用时，`post-detail.sh` 和 `comment.sh` 会报错：`unexpected additional properties ["note_id"]`
- 另外在设置了 HTTP 代理（如 `http_proxy=127.0.0.1:7890`）的环境中，curl 访问 localhost 也会走代理导致 502

## Changes

- `scripts/post-detail.sh`: JSON 参数 `note_id` → `feed_id`
- `scripts/comment.sh`: JSON 参数 `note_id` → `feed_id`
- `scripts/mcp-call.sh`: 帮助文档中 4 处 `note_id` → `feed_id`
- `scripts/mcp-call.sh`: 添加 `export no_proxy` 绕过本地代理
- `SKILL.md`: 参数名同步更新

## Test plan

- [x] `status.sh` 正常返回登录状态
- [x] `search.sh "关键词"` 正常返回搜索结果
- [x] `post-detail.sh <feed_id> <xsec_token>` 正常返回帖子详情和评论
- [x] 在有 HTTP 代理的环境中验证 no_proxy 生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)